### PR TITLE
Fix #11: Add PBXHeadersBuildPhase and PBXHeadersBuildPhaseMerger3.

### DIFF
--- a/src/pbxproj/isa.py
+++ b/src/pbxproj/isa.py
@@ -133,6 +133,13 @@ class PBXSourcesBuildPhase(PBXISA, PBXISADictionaryBound):
     def get_name(self, project):
         return "Sources"
 
+class PBXHeadersBuildPhase(PBXISA, PBXISADictionaryBound):
+    def __init__(self, *args, **kwargs):
+        super(PBXHeadersBuildPhase, self).__init__(*args, **kwargs)
+
+    def get_name(self, project):
+        return "Headers"
+
 class PBXTargetDependency(PBXISA, PBXISADictionaryBound):
     def __init__(self, *args, **kwargs):
         super(PBXTargetDependency, self).__init__(*args, **kwargs)

--- a/src/pbxproj/merge/pbxmerge.py
+++ b/src/pbxproj/merge/pbxmerge.py
@@ -300,6 +300,9 @@ class PBXProjectMerger3(_SimpleDictMerger3):
 class PBXSourcesBuildPhaseMerger3(_SimpleDictMerger3):
     merge_files = create_auto_merge_set("files")
 
+class PBXHeadersBuildPhaseMerger3(_SimpleDictMerger3):
+    merge_files = create_auto_merge_set("files")
+
 class XCBuildConfigurationMerger3(_SimpleDictMerger3):
     def merge_buildSettings(self, base, mine, theirs, result, diff3):
         attribute = "buildSettings"

--- a/src/pbxproj/pbxobjects.py
+++ b/src/pbxproj/pbxobjects.py
@@ -17,8 +17,9 @@ class PBXProjFile(DictionaryBoundObject):
         self._phases = dict()
         phases = (
             ("Frameworks", "PBXFrameworksBuildPhase"),
+            ("Headers", "PBXHeadersBuildPhase"),
             ("Sources", "PBXSourcesBuildPhase"),
-            ("Resources", "PBXResourcesBuildPhase")
+            ("Resources", "PBXResourcesBuildPhase"),
         )
 
         for (section, phase_isa) in phases:


### PR DESCRIPTION
Hi @simonwagner: thanks for the fast reponse.  Unfortunately adding just the 3-way merge class quiets the error but does not appear to correctly merge.  Here's a commit that tries to handle the section explicitly.  It doesn't work for my (complicated) rebase -- it fails with a key error looking up some hex string identifier.  I don't have clean test data for this, so I can't say if your change works for simpler cases, or if my additional changes address the issue, or if there's more to be done :(