### PR TITLE
Added experimental support for objectVersion 48

### DIFF
--- a/src/pbxproj/merge/pbxmerge.py
+++ b/src/pbxproj/merge/pbxmerge.py
@@ -128,8 +128,8 @@ def create_auto_merge_dict(attribute, optional = False):
 
 class PBXProjectFileMerger3(Merger):
     SUPPORTED_ARCHIVE_VERSIONS = set((1,))
-    SUPPORTED_OBJECT_VERSIONS = set((46,47))
-    EXPERIMENTAL_OBJECT_VERSIONS = set((47,))
+    SUPPORTED_OBJECT_VERSIONS = set((46,47,48))
+    EXPERIMENTAL_OBJECT_VERSIONS = set((47,48))
 
     def merge(self, base, mine, theirs):
         result = OrderedDict()


### PR DESCRIPTION
Based on the experimental support for objectVersion 47 (Xcode 8), added similar experimental support for objectVersion 48 (Xcode 9).