### PR TITLE
Add ability to merge currentVersion property for VersionGroup.

### DIFF
--- a/src/pbxproj/merge/pbxmerge.py
+++ b/src/pbxproj/merge/pbxmerge.py
@@ -341,7 +341,16 @@ class PBXVariantGroupMerger3(_SimpleDictMerger3):
     merge_children = create_auto_merge_set("children")
 
 class XCVersionGroupMerger3(_SimpleDictMerger3):
-    merge_files = create_auto_merge_set("children")
+    merge_children = create_auto_merge_set("children")
+    def merge_currentVersion(self, base, mine, theirs, result, diff3):
+        currentVersion = _get_3("currentVersion", base, mine, theirs)
+        if not currentVersion.base == currentVersion.mine or not currentVersion.base == currentVersion.theirs:
+            raise MergeException("can not merge projects with different currentVersion")
+        if not int(currentVersion.base) in self.SUPPORTED_OBJECT_VERSIONS:
+            raise MergeException("can not merge projects with currentVersion %s" % currentVersion.base)
+ 
+        result["currentVersion"] = currentVersion.base
+        return result
 
 Value3 = namedtuple("Value3", ("base", "mine", "theirs"))
 


### PR DESCRIPTION
Partially addresses #26.

This PR adds the ability to merge the currentVersion property for the XCVersionGroup dictionary. If both branches have diverged from base, then it fails. 

This doesn't fix all problems, because often the conflict is that both versions have diverged from base. To fix this, some sort of manual merge or selection mechanism should be introduced in order to allow the user to select which they'd prefer: mine or theirs. (For the time being, my personal version has been modified to always select `theirs` and prints a message warning me about it. This at least allows mergepbx to do the the rest of the merge and allows me to fix it if it's not what I wanted.)